### PR TITLE
Add armv7l as target arch for Raspberry Pi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${MODULE_DIR})
 
 set (I386 "^(i[3-7]|x)86$")
 set (AMD64 "^(x86_|x86-|AMD|amd|x)64$")
-set (ARM32 "^(arm|ARM|A)(32)?$")
+set (ARM32 "^(arm|armv7l|ARM|A)(32)?$")
 set (ARM64 "^(arm|ARM|A|aarch|AARCH)64$")
 
 if (CMAKE_GENERATOR_PLATFORM)


### PR DESCRIPTION
CMAKE_SYSTEM_PROCESSOR is the same as CMAKE_HOST_SYSTEM_PROCESSOR when building for the host system. CMAKE_HOST_SYSTEM_PROCESSOR is `uname -m` on Linux. On RPi 3 `uname -m = armv7l`.

https://cmake.org/cmake/help/v3.18/variable/CMAKE_SYSTEM_PROCESSOR.html