### PR TITLE
Fix PLT_SEL_FILE for Darwin and Linux

### DIFF
--- a/src/plt-elf.c
+++ b/src/plt-elf.c
@@ -196,7 +196,7 @@ plt_lib plt_get_lib(plt_ctx ctx, const char *name)
             }
         } else if (sel == PLT_SEL_NONE || sel == PLT_SEL_FILE) {
             const char *libname = get_lib_name(ctx, lm);
-            if (!strcmp(name, libname))
+            if (!strcmp(val, libname))
                 return lm;
         } else if (sel == PLT_SEL_SYM) {
             if (get_offsets(ctx, lm, val, NULL) > 0)

--- a/src/plt-mach-o.c
+++ b/src/plt-mach-o.c
@@ -80,7 +80,7 @@ plt_lib plt_get_lib(plt_ctx ctx, const char *name)
                 return i;
         } else if (sel == PLT_SEL_NONE || sel == PLT_SEL_FILE) {
             const char *img_name = _dyld_get_image_name(i);
-            if (img_name && !strcmp(img_name, name))
+            if (img_name && !strcmp(img_name, val))
                 return i;
         } else if (sel == PLT_SEL_SYM) {
             plt_offset *off = plt_get_offsets(ctx, i, val, NULL);


### PR DESCRIPTION
The variable `name` contains everything after the `@`, which includes the `file:` prefix. The variable `val` should contain everything after the `file:` prefix, which should be appropriate for comparison with the library file name.