### PR TITLE
Further Mac build fix proposal.

### DIFF
--- a/src/vitals.c
+++ b/src/vitals.c
@@ -196,7 +196,7 @@ void mmk_init_vital_functions(plt_ctx ctx)
     INIT_VITAL_FUNC(malloc);
     INIT_VITAL_FUNC(realloc);
     INIT_VITAL_FUNC(free);
-#ifdef MMK_EXE_FMT_ELF
+#if defined(MMK_EXE_FMT_ELF) || defined(MMK_EXE_FMT_MACH_O)
     INIT_VITAL_FUNC(mprotect);
 #endif
 }


### PR DESCRIPTION
mprotect symbol is needed too. also __clear_cache seems buggy on
 ARM64 thus calling directly related MacOS feature.