### PR TITLE
Mark asm code with no-executable-stack.

### DIFF
--- a/src/asm/trampoline-aarch64.S
+++ b/src/asm/trampoline-aarch64.S
@@ -76,3 +76,5 @@ ret_ctx:
 .globl MANGLE(mmk_trampoline_end)
 MANGLE(mmk_trampoline_end):
     nop
+
+.section  .note.GNU-stack, "", @progbits

--- a/src/asm/trampoline-x86_64-systemv.S
+++ b/src/asm/trampoline-x86_64-systemv.S
@@ -111,3 +111,5 @@ ret_ctx:                                        // Return context
 .globl MANGLE(mmk_trampoline_end)
 MANGLE(mmk_trampoline_end):
     nop
+
+.section  .note.GNU-stack, "", @progbits


### PR DESCRIPTION
Newer versions of binutils (2.39 and above) complain if you have assembly without explicitly marking that it is not using an executable stack (see
https://www.redhat.com/en/blog/linkers-warnings-about-executable-stacks-and-segments for more details).  Mark it here to quiet that warning.