### PR TITLE
Define mmk_noreturn if __STDC_VERSION__ >= 201112L

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -28,6 +28,7 @@
 
 # if __STDC_VERSION__ >= 201112L
 #  include <stdnoreturn.h>
+#  define mmk_noreturn _Noreturn
 # elif defined __GNUC__
 #  define mmk_noreturn __attribute__((noreturn))
 # elif defined _MSC_VER


### PR DESCRIPTION
If `CMAKE_C_STANDARD` is set to 11 (e.g., globally), then `mmk_noreturn` is never defined, which results in errors like this:

```
In file included from /home/user/ros2_ws/build/mimick_vendor/mimick_vendor-prefix/src/mimick_vendor/src/plt.c:25:
/home/user/ros2_ws/build/mimick_vendor/mimick_vendor-prefix/src/mimick_vendor/src/vitals.h:46:13: error: expected ‘;’ before ‘void’
   46 | mmk_noreturn void mmk_panic(const char *, ...);
      |             ^~~~~
      |             ;
```

`_Noreturn` is deprecated in C23, but I'm not sure if we should worry about that just yet. See https://en.cppreference.com/w/c/language/_Noreturn.

Relates to https://github.com/Snaipe/Mimick/issues/28, but using C99 is not really a great solution.