### PR TITLE
Stop forcing users to build with -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,7 @@ script:
       -Wno-dev
       -DCMAKE_BUILD_TYPE=${CONFIGURATION}
       -DCMAKE_INSTALL_PREFIX=mimick-${TRAVIS_TAG}
+      -DCMAKE_C_FLAGS="-Werror"
       ${CMAKE_OPTS}
       ..
   - TERM=dumb cmake --build . -- -j4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,7 @@ install:
       -DCMAKE_INSTALL_PREFIX="mimick-%RELEASE_NAME%"
       -DCMAKE_BUILD_TYPE="%CONFIGURATION%"
       -DCMAKE_SYSTEM_PROCESSOR="%PLATFORM%"
+      -DCMAKE_C_FLAGS="-Werror"
       %CMAKE_OPTS%
       -G "%GENERATOR%"
       ..

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT MSVC)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic -Werror")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic")
 endif ()
 
 add_subdirectory (strdup)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT MSVC)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic -Werror")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic")
 endif ()
 
 add_library (foo SHARED libfoo.c)


### PR DESCRIPTION
Forcing users to build with -Werror only punishes those building with newer compilers or toolchains than those in the repository CI. While maintaining a warning-free build is a noble cause, the repository CI can be adjusted so that it is enforced only for the platforms you're testing and not every single user.